### PR TITLE
Retry http bad status

### DIFF
--- a/gator/common/http_api.py
+++ b/gator/common/http_api.py
@@ -56,7 +56,7 @@ class HTTPAPI:
             full_url = f"http://{self.url}{self.ROUTE_PREFIX}/{route}"
             for _ in range(self.retries):
                 try:
-                    async with self.session.get(full_url) as resp:
+                    async with self.session.get(full_url, raise_for_status=True) as resp:
                         data = await resp.json()
                         if data.get("result", None) != "success":
                             print(
@@ -64,7 +64,7 @@ class HTTPAPI:
                                 file=sys.stderr,
                             )
                         return data
-                except aiohttp.ClientConnectionError:
+                except (aiohttp.ClientConnectionError, aiohttp.ClientResponseError):
                     await asyncio.sleep(self.delay)
             else:
                 print(
@@ -89,7 +89,9 @@ class HTTPAPI:
             full_url = f"http://{self.url}{self.ROUTE_PREFIX}/{route}"
             for _ in range(10):
                 try:
-                    async with self.session.post(full_url, json=kwargs) as resp:
+                    async with self.session.post(
+                        full_url, json=kwargs, raise_for_status=True
+                    ) as resp:
                         data = await resp.json()
                         if data.get("result", None) != "success":
                             print(
@@ -97,7 +99,7 @@ class HTTPAPI:
                                 file=sys.stderr,
                             )
                         return data
-                except aiohttp.ClientConnectionError:
+                except (aiohttp.ClientConnectionError, aiohttp.ClientResponseError):
                     await asyncio.sleep(0.1)
             else:
                 print(


### PR DESCRIPTION
If the first attempt connects but receives a bad status (with a non-json message), currently get:

> ERROR    ContentTypeError: 504, message='Attempt to decode JSON with unexpected mimetype: text/html',                                                
                    url='/api/job/1153/heartbeat' 

This will retry that case
