### PR TITLE
Show running jobs above progress bar

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -59,7 +59,7 @@ jobs:
       run: |
         poe docs
     - name: Upload documentation artifact
-      uses: actions/upload-pages-artifact@v1
+      uses: actions/upload-pages-artifact@v3
       with:
         path: ./site
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -104,5 +104,5 @@ jobs:
     - name: Archive code coverage results
       uses: actions/upload-artifact@v4
       with:
-        name: pytest-cov
-        path: htmlcov
+        name: pytest-cov-${{ matrix.python-version }}
+        path: htmlcov-${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -70,7 +70,7 @@ jobs:
     steps:
       - name: Deploy to GitHub pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4
 
   unit_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -102,7 +102,7 @@ jobs:
       run: |
         poe example
     - name: Archive code coverage results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pytest-cov
         path: htmlcov

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -105,4 +105,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: pytest-cov-${{ matrix.python-version }}
-        path: htmlcov-${{ matrix.python-version }}
+        path: htmlcov

--- a/gator-hub/src/features/JobDashboard/components/RegistrationTable.tsx
+++ b/gator-hub/src/features/JobDashboard/components/RegistrationTable.tsx
@@ -10,17 +10,6 @@ import { TreeKey } from "./Dashboard/lib/tree";
 import { ApiJob } from "@/types/job";
 import { Reader } from "../lib/readers";
 
-enum Severity {
-    CRITICAL = 50,
-    FATAL = CRITICAL,
-    ERROR = 40,
-    WARNING = 30,
-    WARN = WARNING,
-    INFO = 20,
-    DEBUG = 10,
-    NOTSET = 0
-}
-
 enum Status {
     ERROR,
     LOADING,

--- a/gator-hub/src/features/JobDashboard/lib/jobtree.tsx
+++ b/gator-hub/src/features/JobDashboard/lib/jobtree.tsx
@@ -4,7 +4,7 @@
  */
 
 import { ApiJob, Job, JobState } from "@/types/job";
-import Tree, { TreeKey, TreeNode } from "../components/Dashboard/lib/tree";
+import Tree, { TreeNode } from "../components/Dashboard/lib/tree";
 import moment from "moment";
 
 export type JobNode = TreeNode<Job>;

--- a/gator/common/db_client.py
+++ b/gator/common/db_client.py
@@ -235,9 +235,9 @@ async def websocket_client(websocket: WebsocketWrapper):
 async def child_client(child: Child):
     if child.state in [JobState.PENDING, JobState.LAUNCHED]:
         client = None
-    elif JobState.COMPLETE:
+    elif child.state == JobState.COMPLETE:
         client = database_client(path=child.tracking / "db.sqlite")
-    elif JobState.STARTED:
+    elif child.state == JobState.STARTED:
         assert child.ws is not None, "Child started but no websocket!"
         client = websocket_client(child.ws)
 

--- a/gator/launch_progress.py
+++ b/gator/launch_progress.py
@@ -14,36 +14,121 @@
 
 import asyncio
 import os
+from pathlib import Path
 from typing import Union
 
-from rich.console import Console
+from rich.console import Console, ConsoleOptions, RenderResult
 from rich.live import Live
+from rich.rule import Rule
 from rich.table import Table
 from rich.tree import Tree
 
 from .common.layer import BaseLayer
 from .common.progress import PassFailBar
 from .common.summary import Summary
+from .common.types import ApiJob
 from .launch import launch as launch_base
+
+
+class ProgressDisplay:
+    """
+    Display element for task progress including failed tasks, running tasks
+    and a progress bar.
+    """
+
+    def __init__(self, glyph: str, max_fails: int = 10, max_running: int = 10):
+        self.max_rows = 10
+        self.bar = PassFailBar(glyph, 1, 0, 0, 0)
+        self.failures: dict[str, ApiJob] = {}
+        self.running: dict[str, ApiJob] = {}
+        self.max_fails = max_fails
+        self.max_running = max_running
+
+    def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
+        if self.failures:
+            yield Rule("▼ Failed Jobs ▼")
+
+            fail_table = Table(
+                expand=True,
+                show_header=False,
+                show_footer=False,
+                collapse_padding=True,
+                show_lines=False,
+                show_edge=False,
+                border_style="none",
+                box=None,
+                padding=0,
+            )
+
+            for i, (ident, job) in enumerate(self.failures.items()):
+                if i > self.max_fails:
+                    fail_table.add_row("", f"and {i - self.max_fails} more...")
+                    break
+                messages = (Path(job["db_file"]).parent / "messages.log").as_posix()
+                fail_table.add_row(ident, messages)
+
+            yield fail_table
+
+        yield self.bar
+
+        if self.running:
+            run_table = Table(
+                expand=True,
+                show_header=False,
+                show_footer=False,
+                collapse_padding=True,
+                show_lines=False,
+                show_edge=False,
+                border_style="none",
+                box=None,
+                padding=0,
+            )
+
+            for i, (ident, job) in enumerate(self.running.items()):
+                if i > self.max_running:
+                    run_table.add_row("", f"and {i - self.max_running} more...")
+                    break
+                messages = (Path(job["db_file"]).parent / "messages.log").as_posix()
+                run_table.add_row(ident, messages)
+
+            yield run_table
+
+            yield Rule("▲ Running Jobs ▲")
+
+    async def update(self, layer: BaseLayer, summary: Summary):
+        self.bar.update(summary)
+
+        for job_id in summary.failed_ids:
+            display_id = ".".join(job_id)
+            if display_id in self.failures:
+                continue
+            job = await layer.resolve(job_id[1:])
+            self.failures[display_id] = job
+
+        running = {}
+        for job_id in summary.running_ids:
+            display_id = ".".join(job_id)
+            job = await layer.resolve(job_id[1:])
+            running[display_id] = job
+        self.running = running
 
 
 async def launch(glyph: str = "🐊 Gator", **kwargs) -> Summary:
     # Create console
     # Unset COLUMNS and LINES as they prevent automatic resizing
     console = Console(log_path=False, _environ={**os.environ, "COLUMNS": "", "LINES": ""})
-    # Create table
-    table = Table(expand=True, show_edge=False, show_header=False)
-    # Create a progress bar
-    bar = PassFailBar(glyph, 1, 0, 0, 0)
-    table.add_row(bar)
+    # Create progress display
+    progress = ProgressDisplay(glyph, 5)
+
     # Start console
-    live = Live(table, refresh_per_second=4, console=console)
+    live = Live(progress, refresh_per_second=4, console=console)
     live.start(refresh=True)
 
     # Create an update function
-    def _update(_layer: BaseLayer, summary: Summary, /, tree: Union[Tree, None] = None):
-        # Update the progress bars
-        bar.update(summary)
+    async def _update(layer: BaseLayer, summary: Summary, /, tree: Union[Tree, None] = None):
+        # Update the progress display
+        await progress.update(layer, summary)
+
         # Display the tree
         if tree:
 

--- a/gator/launch_progress.py
+++ b/gator/launch_progress.py
@@ -37,15 +37,15 @@ class ProgressDisplay:
     and a progress bar.
     """
 
-    def __init__(self, glyph: str, max_fails: int = 10, max_running: int = 10):
+    def __init__(self, glyph: str, max_fail_rows: int = 10, max_running_rows: int = 10):
         self.bar = PassFailBar(glyph, 1, 0, 0, 0)
         self.failures: dict[str, ApiJob] = {}
         self.running: dict[str, ApiJob] = {}
-        self.max_fails = max_fails
-        self.max_running = max_running
+        self.max_fail_rows = max_fail_rows
+        self.max_running_rows = max_running_rows
 
     def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
-        if self.failures:
+        if self.max_fail_rows and self.failures:
             yield Rule("▼ Failed Jobs ▼", style=Style(color="red"))
 
             fail_table = Table(
@@ -60,7 +60,7 @@ class ProgressDisplay:
             )
 
             for i, (ident, job) in enumerate(self.failures.items()):
-                if i == self.max_fails:
+                if i == self.max_fail_rows:
                     excess = len(self.failures) - i
                     if excess:
                         fail_table.add_row(f"... and {excess} more...", "")
@@ -70,9 +70,9 @@ class ProgressDisplay:
 
             yield fail_table
 
-        yield self.bar
+        if self.max_running_rows and self.running:
+            yield Rule("▼ Running Jobs ▼", style=Style(color="default"))
 
-        if self.running:
             run_table = Table(
                 expand=True,
                 show_header=False,
@@ -85,7 +85,7 @@ class ProgressDisplay:
             )
 
             for i, (ident, job) in enumerate(self.running.items()):
-                if i == self.max_running:
+                if i == self.max_running_rows:
                     excess = len(self.running) - i
                     if excess:
                         run_table.add_row(f"... and {excess} more...", "")
@@ -96,7 +96,7 @@ class ProgressDisplay:
 
             yield run_table
 
-            yield Rule("▲ Running Jobs ▲", style=Style(color="default"))
+        yield self.bar
 
     async def update(self, layer: BaseLayer, summary: Summary):
         self.bar.update(summary)

--- a/gator/launch_progress.py
+++ b/gator/launch_progress.py
@@ -121,7 +121,7 @@ async def launch(glyph: str = "🐊 Gator", **kwargs) -> Summary:
     # Unset COLUMNS and LINES as they prevent automatic resizing
     console = Console(log_path=False, _environ={**os.environ, "COLUMNS": "", "LINES": ""})
     # Create progress display
-    progress = ProgressDisplay(glyph, 3, 3)
+    progress = ProgressDisplay(glyph, 10, 5)
 
     # Start console
     live = Live(progress, refresh_per_second=4, console=console)

--- a/gator/scheduler/common.py
+++ b/gator/scheduler/common.py
@@ -114,3 +114,10 @@ class BaseScheduler:
         infrastructure.
         """
         return
+
+    @abc.abstractmethod
+    async def stop(self) -> None:
+        """
+        Stop scheduling tasks
+        """
+        return

--- a/gator/scheduler/local.py
+++ b/gator/scheduler/local.py
@@ -40,6 +40,7 @@ class LocalScheduler(BaseScheduler):
         self.complete = {}
         self.monitors = {}
         self.slots = {}
+        self.terminated = False
         self.concurrency = self.get_option("concurrency", 1, int)
         self.update = asyncio.Event()
         if self.concurrency < 0:
@@ -78,6 +79,9 @@ class LocalScheduler(BaseScheduler):
                     if slots < 1:
                         self.update.clear()
                         await self.update.wait()
+
+                if self.terminated:
+                    return
                 # Pop the next task
                 task = remaining.pop(0)
                 # Grant 1 slot for a job, up to max jobs for a group/array
@@ -110,3 +114,6 @@ class LocalScheduler(BaseScheduler):
     async def wait_for_all(self):
         await self.launch_task
         await asyncio.gather(*self.monitors.values())
+
+    async def stop(self):
+        self.terminated = True

--- a/gator/tier.py
+++ b/gator/tier.py
@@ -391,7 +391,7 @@ class Tier(BaseLayer):
                 child.e_complete.set()
             return
         # Accumulate results for all dependencies
-        await self.logger.info(f"Dependencies of {ident} complete, testing for launch")
+        await self.logger.debug(f"Dependencies of {ident} complete, testing for launch")
         by_id = {x.spec.ident: x.entry.result for x in wait_for}
         # Check if pass/fail criteria is met
         all_ok = True

--- a/gator/tier.py
+++ b/gator/tier.py
@@ -123,10 +123,13 @@ class Tier(BaseLayer):
     async def stop(self, **kwargs) -> None:
         await super().stop(**kwargs)
         await self.logger.warning("Stopping all jobs")
+        await self.scheduler.stop()
         async with self.lock:
             for child in self.jobs_launched.values():
                 if child.ws:
                     await child.ws.stop(posted=True)
+                else:
+                    child.e_complete.set()
 
     async def get_tree(self, **_) -> GetTreeResponse:
         tree = {}

--- a/gator/wrapper.py
+++ b/gator/wrapper.py
@@ -87,6 +87,10 @@ class Wrapper(BaseLayer):
             summary.failed_ids = [[self.spec.ident]]
         else:
             summary.failed_ids = []
+        if self.started and not self.complete:
+            summary.running_ids = [[self.spec.ident]]
+        else:
+            summary.running_ids = []
         return summary
 
     async def __handle_metric(self, name: str, value: int, **_) -> MetricResponse:


### PR DESCRIPTION
Adds a small display showing running and failed jobs when running with launch progress

Fixes a bug where crtl-c doesn't kill a workflow. This happens when a tier launches more jobs than the scheduler has concurrency (which is fine). The tier terminates and tries to kill its jobs via the websocket connection, but skips over jobs which haven't haven't started yet and thus don't have a WS connection. This results in the scheduler continuing to launch new jobs and the tier left waiting for the scheduler to finish them. I've added a hook to stop the scheduler from launching new jobs, and modified the tier to set the complete event on jobs it can't kill via websocket.

Fixes a bug in db_client resulting in the websocket connection never being used.

Fixes a lint error for the dashboard code