### PR TITLE
Fix #22: Slurm expiry had inverted condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ A simple specification may look like this:
   - !JobArray
       ident     : counting
       on_pass:
-        - say_hi
+        - inner
       repeats: 4
       jobs   :
       - !Job

--- a/gator/scheduler/slurm.py
+++ b/gator/scheduler/slurm.py
@@ -69,7 +69,7 @@ class SlurmScheduler(BaseScheduler):
 
     @property
     def expired(self) -> bool:
-        return (self._expiry is None) or (self._expiry >= datetime.now())
+        return (self._expiry is None) or (self._expiry <= datetime.now())
 
     @property
     def token(self) -> str:


### PR DESCRIPTION
The fix is to test that the expiry time is in the past, i.e. less than the current time.

Also tweaked the README to fix the example specification.